### PR TITLE
Fix the desktop-mode problem a better way

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -2,10 +2,8 @@
 ;;; TR's .emacs file
 ;;;
 
-;; Stupid desktop-save hack ... UTF-8 problem? Not really sure.
-(setq Î nil)
-
 (require 'desktop)
+(setq desktop-file-version (format "%s" desktop-file-version))
 (desktop-save-mode 1)
 (setq desktop-dirname "~/.emacs.d/")
 (defun my-desktop-save ()


### PR DESCRIPTION
I used to have problems with desktop-mode as well, but finally tracked it down (I ran across this page while searching the internet).  I've been using a newer version in which the bug is fixed, but then ran into it again.  The problem is that `desktop-file-version` is an integer 206 which gets written to the file as a character.   In new versions, they changed it to be a string so that it gets written correctly.  Anyway, hope that helps.
